### PR TITLE
Upgrade Sbt version to 0.11.3

### DIFF
--- a/project-code/project/build.properties
+++ b/project-code/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3

--- a/sample/project/build.properties
+++ b/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3


### PR DESCRIPTION
TypeSafe repository doesn't contains Sbt 0.11.2 (http://repo.typesafe.com/typesafe/releases/org.scala-sbt/sbt_2.9.1/).
