### PR TITLE
Use request.getQueryString() instead of getParameterMap()

### DIFF
--- a/project-code/core/servlet30/src/main/scala/Play2Servlet30.scala
+++ b/project-code/core/servlet30/src/main/scala/Play2Servlet30.scala
@@ -6,6 +6,7 @@ import javax.servlet.http._
 import java.io._
 import java.util.concurrent.atomic._
 import java.util.Arrays
+import java.net.URLDecoder
 
 import play.api._
 import play.api.mvc._
@@ -46,7 +47,16 @@ class Play2Servlet extends play.core.server.servlet.Play2Servlet[Tuple2[AsyncCon
   }
 
   protected override def getHttpParameters(request: HttpServletRequest): Map[String, Seq[String]] = {
-    Map.empty[String, Seq[String]] ++ request.getParameterMap.asScala.mapValues(Arrays.asList(_: _*).asScala)
+    request.getQueryString match {
+      case null|"" => Map.empty
+      case queryString => queryString.replaceFirst("^?", "").split("&").map(_.split("=")).map { array => 
+        array.length match {
+          case 0 => None
+          case 1 => Some(URLDecoder.decode(array(0), "UTF-8") -> "")
+          case _ => Some(URLDecoder.decode(array(0), "UTF-8") -> URLDecoder.decode(array(1), "UTF-8"))
+        }
+      }.flatten.groupBy(_._1).map { case (key, value) => key -> value.map(_._2).toSeq }.toMap
+    }
   }
 
   protected override def getHttpRequest(execContext: Tuple2[AsyncContext, AsyncListener]): RichHttpServletRequest = {

--- a/project-code/integration-tests/src/test/scala/AllTests.scala
+++ b/project-code/integration-tests/src/test/scala/AllTests.scala
@@ -202,7 +202,7 @@ abstract class AbstractPlay2WarTests extends FeatureSpec with GivenWhenThen with
 
     scenario("Container reads POST parameters") {
 
-      val page = givenWhenGet("a page", "/echo", method = "POST", parameters = Map("param1" -> "value1", "param2" -> "value2"))
+      val page = givenWhenGet("a page", "/echo2", method = "POST", parameters = Map("param1" -> "value1", "param2" -> "value2"))
 
       then("page body should contain parameters values")
       page.map { p =>

--- a/sample/common/app/controllers/Application.scala
+++ b/sample/common/app/controllers/Application.scala
@@ -124,6 +124,10 @@ object Application extends Controller {
     Ok(views.html.echo(request.queryString))
   }
   
+  def echo2 = Action { request =>
+    Ok(views.html.echo(request.body.asFormUrlEncoded.get))
+  }
+  
   def uploadForm = Action { 
     Ok(views.html.uploadForm())
   }

--- a/sample/common/conf/routes
+++ b/sample/common/conf/routes
@@ -20,7 +20,7 @@ GET     /bigContent                 controllers.Application.bigContent
 GET     /chunkedBigContent          controllers.Application.chunkedBigContent
 
 GET		/echo						controllers.Application.echo
-POST	/echo						controllers.Application.echo
+POST	/echo2						controllers.Application.echo2
 
 GET		/uploadForm					controllers.Application.uploadForm
 POST	/upload						controllers.Application.upload


### PR DESCRIPTION
`request.body.asFormUrlEncoded.get` returns an empty map because Play2Servlet25 and Play2Servlet30 invoke `request.getParameterMap()` before `request.getInputStream()` to retrieve request parameters for queryString.

In the Servlet API, only either one of  them is available in the same request. So Play2Servlet25 and Play2Servlet30 should retrieve queryString using `request.getQueryString()` instead of `getParameterMap()`.

This pull request contains #102 and fix of the integration test.
