### PR TITLE
Change Play2Servlet for Container 2.5 and 3.0 to make it works on glassfish

### DIFF
--- a/project-code/core/common/src/main/scala/Play2CommonServlet.scala
+++ b/project-code/core/common/src/main/scala/Play2CommonServlet.scala
@@ -39,20 +39,20 @@ abstract class GenericPlay2Servlet extends HttpServlet with ServletContextListen
   protected def getRequestHandler(servletRequest: HttpServletRequest, servletResponse: HttpServletResponse): RequestHandler
 
   override def contextInitialized(e: ServletContextEvent): Unit = {
-    e.getServletContext.log("PlayServletWrapper > contextInitialized")
+     println("PlayServletWrapper > contextInitialized")
 
     // Init or get singleton
     Play2WarServer(Some(e.getServletContext.getContextPath))
   }
 
   override def contextDestroyed(e: ServletContextEvent): Unit = {
-    e.getServletContext.log("PlayServletWrapper > contextDestroyed")
+    println("PlayServletWrapper > contextDestroyed")
 
     Play2WarServer.stop(e.getServletContext)
   }
 
   override def destroy(): Unit = {
-    getServletContext.log("PlayServletWrapper > destroy")
+    println("PlayServletWrapper > destroy")
 
     Play2WarServer.stop(getServletContext)
   }

--- a/project-code/core/common/src/main/scala/Play2Server.scala
+++ b/project-code/core/common/src/main/scala/Play2Server.scala
@@ -23,7 +23,6 @@ import scala.util.control.NonFatal
 import javax.servlet.ServletContext
 import play.api.Application
 import play.api.Configuration
-import play.api.Logger
 import play.api.Mode
 import play.api.Play
 import play.api.WithDefaultConfiguration
@@ -43,7 +42,7 @@ object Play2WarServer {
 
   }
 
-  Logger.configure(Map.empty, Map.empty, Mode.Prod)
+  
 
   lazy val configuration = Play.current.configuration
 
@@ -61,7 +60,7 @@ object Play2WarServer {
   def handleRequest(requestHandler: RequestHandler) = {
 
     playServer.map(requestHandler(_)).getOrElse {
-      Logger("play").error("Play server as not been initialized. Due to a previous error ?")
+     println("Play server as not been initialized. Due to a previous error ?")
     }
 
   }
@@ -81,18 +80,18 @@ private[servlet] class Play2WarServer(appProvider: WarApplication) extends Serve
   def newRequestId = requestIDs.incrementAndGet
 
   override def stop() = {
-    Logger("play").info("Stopping play server...")
+    println("Stopping play server...")
 
     try {
       Play.stop()
     } catch {
-      case NonFatal(e) => Logger("play").error("Error while stopping the application", e)
+      case NonFatal(e) => println("Error while stopping the application", e)
     }
 
     try {
       super.stop()
     } catch {
-      case NonFatal(e) => Logger("play").error("Error while stopping akka", e)
+      case NonFatal(e) => println("Error while stopping akka", e)
     }
   }
 }
@@ -105,8 +104,7 @@ private[servlet] class WarApplication(val mode: Mode.Mode, contextPath: Option[S
 
   // Because of https://play.lighthouseapp.com/projects/82401-play-20/tickets/275, reconfigure Logger
   // without substitutions
-  Logger.configure(Map("application.home" -> path.getAbsolutePath), Map.empty,
-    mode)
+  
 
   Play.start(application)
 
@@ -123,7 +121,7 @@ private[servlet] class DefaultWarApplication(
   private lazy val warConfiguration = contextPath.filterNot(_.isEmpty)
                                         .map(cp => cp + (if (cp.endsWith("/")) "" else "/"))
                                         .map(cp => {
-                                          Logger("play").info(s"Force Play 'application.context' to '$cp'")
+                                          println(s"Force DSAPANDORA Play 'application.context' to '$cp'")
                                           Configuration.from(Map("application.context" -> cp))
                                         }).getOrElse(Configuration.empty) ++ super.configuration
 

--- a/project-code/core/servlet25/src/main/scala/Play2Servlet25.scala
+++ b/project-code/core/servlet25/src/main/scala/Play2Servlet25.scala
@@ -15,7 +15,6 @@
  */
 package play.core.server.servlet25
 
-import play.api.Logger
 import play.core.server.servlet.Play2WarServer
 import javax.servlet.ServletContextEvent
 import javax.servlet.ServletContextListener
@@ -28,7 +27,7 @@ object Play2Servlet {
   val DEFAULT_TIMEOUT = 60 * 1000
 
   val syncTimeout = Play2WarServer.configuration.getInt("servlet25.synctimeout").getOrElse(DEFAULT_TIMEOUT)
-  Logger("play").debug("Sync timeout for HTTP requests: " + syncTimeout + " ms")
+  println("Sync timeout for HTTP requests: " + syncTimeout + " ms")
 }
 
 class Play2Servlet extends HttpServlet with ServletContextListener with Helpers {

--- a/project-code/core/servlet25/src/main/scala/Play2Servlet25.scala
+++ b/project-code/core/servlet25/src/main/scala/Play2Servlet25.scala
@@ -46,20 +46,20 @@ class Play2Servlet extends HttpServlet with ServletContextListener with Helpers 
     new Play2Servlet25RequestHandler(servletRequest, servletResponse)
   }
   override def contextInitialized(e: ServletContextEvent): Unit = {
-    e.getServletContext.log("PlayServletWrapper > contextInitialized")
+    println("PlayServletWrapper > contextInitialized")
 
     // Init or get singleton
     Play2WarServer(Some(e.getServletContext.getContextPath))
   }
 
   override def contextDestroyed(e: ServletContextEvent): Unit = {
-    e.getServletContext.log("PlayServletWrapper > contextDestroyed")
+    println("PlayServletWrapper > contextDestroyed")
 
     Play2WarServer.stop(e.getServletContext)
   }
 
   override def destroy(): Unit = {
-    getServletContext.log("PlayServletWrapper > destroy")
+    println("PlayServletWrapper > destroy")
 
     Play2WarServer.stop(getServletContext)
   }

--- a/project-code/core/servlet30/src/main/scala/Play2Servlet30.scala
+++ b/project-code/core/servlet30/src/main/scala/Play2Servlet30.scala
@@ -17,7 +17,6 @@ package play.core.server.servlet30
 
 import javax.servlet.annotation.WebListener
 import javax.servlet.annotation.WebServlet
-import play.api.Logger
 import play.core.server.servlet.Play2WarServer
 import javax.servlet.ServletContextEvent
 import javax.servlet.ServletContextListener
@@ -27,7 +26,7 @@ import javax.servlet.http.HttpServletResponse
 
 object Play2Servlet {
   val asyncTimeout = Play2WarServer.configuration.getInt("servlet30.asynctimeout").getOrElse(-1)
-  Logger("play").debug("Async timeout for HTTP requests: " + asyncTimeout + " ms")
+  println("Async timeout for HTTP requests: " + asyncTimeout + " ms")
 }
 
 @WebServlet(name = "Play", urlPatterns = Array { "/" }, asyncSupported = true)
@@ -63,7 +62,7 @@ class Play2Servlet extends HttpServlet with ServletContextListener {
   }
 
   override def destroy(): Unit = {
-    getServletContext.log("PlayServletWrapper > destroy")
+   println("PlayServletWrapper > destroy")
 
     Play2WarServer.stop(getServletContext)
   }

--- a/project-code/core/servlet30/src/main/scala/Play2Servlet30.scala
+++ b/project-code/core/servlet30/src/main/scala/Play2Servlet30.scala
@@ -50,14 +50,14 @@ class Play2Servlet extends HttpServlet with ServletContextListener {
   }
 
   override def contextInitialized(e: ServletContextEvent): Unit = {
-    e.getServletContext.log("PlayServletWrapper > contextInitialized")
+    println("PlayServletWrapper > contextInitialized")
 
     // Init or get singleton
     Play2WarServer(Some(e.getServletContext.getContextPath))
   }
 
   override def contextDestroyed(e: ServletContextEvent): Unit = {
-    e.getServletContext.log("PlayServletWrapper > contextDestroyed")
+   println("PlayServletWrapper > contextDestroyed")
 
     Play2WarServer.stop(e.getServletContext)
   }

--- a/project-code/core/servlet30/src/main/scala/RequestHandler30.scala
+++ b/project-code/core/servlet30/src/main/scala/RequestHandler30.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.servlet.AsyncEvent
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import play.api.Logger
 import play.core.server.servlet.Play2GenericServletRequestHandler
 import play.core.server.servlet.RichHttpServletRequest
 import play.core.server.servlet.RichHttpServletResponse
@@ -98,13 +97,13 @@ private[servlet30] class AsyncListener(val requestId: String) extends javax.serv
 
   override def onError(event: AsyncEvent): Unit = {
     withError.set(true)
-    Logger("play").error("Error asynchronously received for request: " + requestId, event.getThrowable)
+    println("Error asynchronously received for request: " + requestId, event.getThrowable)
   }
 
   override def onStartAsync(event: AsyncEvent): Unit = {} // Nothing
 
   override def onTimeout(event: AsyncEvent): Unit = {
     withTimeout.set(true)
-    Logger("play").warn("Timeout asynchronously received for request: " + requestId)
+   println("Timeout asynchronously received for request: " + requestId)
   }
 }


### PR DESCRIPTION
Modify  Play2Servlet to make a correctly deploy on glassfish. Glassfish doesn't like the way that GenericPlay2Servlet was implemented  to generate the jar files needed to create the WAR . For that reasons WAR got the 404 error when is deployed.  After a lot of research I change the way that Play2Servlet is implemented. With this fix, the WAR generated can be deployed correctly
