### PR TITLE
issue #95: asynchron output for servlet 3.1

### DIFF
--- a/project-code/core/servlet30/src/main/scala/RequestHandler30.scala
+++ b/project-code/core/servlet30/src/main/scala/RequestHandler30.scala
@@ -41,7 +41,7 @@ class Play2Servlet30RequestHandler(servletRequest: HttpServletRequest)
   }
 
   protected override def onHttpResponseComplete() = {
-    asyncContext.complete
+    asyncContext.complete()
   }
 
   protected override def getHttpRequest(): RichHttpServletRequest = {

--- a/project-code/integration-tests/src/test/scala/com/github/play2war/plugin/it/AllTests.scala
+++ b/project-code/integration-tests/src/test/scala/com/github/play2war/plugin/it/AllTests.scala
@@ -630,8 +630,8 @@ class Jetty90xTests extends AbstractPlay2WarTests with Servlet30Container with J
 
 @RunWith(classOf[JUnitRunner])
 class Jetty91xTests extends AbstractPlay2WarTests with Servlet31Container with Java7 {
-  override def containerUrl = "http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.1.3.v20140225/jetty-distribution-9.1.3.v20140225.tar.gz"
-  override def containerFileNameInCloudbeesCache = Option("jetty-distribution-9.1.3.v20140225.tar.gz")
+  override def containerUrl = "http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.1.5.v20140505/jetty-distribution-9.1.5.v20140505.tar.gz"
+  override def containerFileNameInCloudbeesCache = Option("jetty-distribution-9.1.5.v20140505.tar.gz")
   override def containerName = "jetty9x"
 }
 

--- a/project-code/integration-tests/src/test/scala/com/github/play2war/plugin/runners/Jetty91xRunner.scala
+++ b/project-code/integration-tests/src/test/scala/com/github/play2war/plugin/runners/Jetty91xRunner.scala
@@ -6,7 +6,7 @@ import java.io.File
 object Jetty91xRunner extends App {
 
   val cargoContainer = new CargoContainerManager with Servlet30Container with Java7 {
-    override def containerUrl = "http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.1.3.v20140225/jetty-distribution-9.1.3.v20140225.tar.gz"
+    override def containerUrl = "http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.1.5.v20140505/jetty-distribution-9.1.5.v20140505.tar.gz"
     override def containerName = "jetty9x"
   }
 

--- a/project-code/project/Build.scala
+++ b/project-code/project/Build.scala
@@ -88,7 +88,7 @@ object Build extends Build {
 
       libraryDependencies += "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test",
       libraryDependencies += "junit" % "junit" % "4.10" % "test",
-      libraryDependencies += "org.codehaus.cargo" % "cargo-core-uberjar" % "1.4.7" % "test",
+      libraryDependencies += "org.codehaus.cargo" % "cargo-core-uberjar" % "1.4.8" % "test",
       libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.13" % "test",
 
       parallelExecution in Test := false,


### PR DESCRIPTION
The handling of a play result in the default request handler is moved
to pushPlayResultToServletOS. This handling stayed the same. This change
should not have any impact on the existing servlet wrapper for servlet < 3.1.

For servlet 3.1, pushPlayResultToServletOS is overwritten to provide a
non-blocking asynchron handling based on the new WriteListener.
